### PR TITLE
feat(routing): added util method to replace FS formatting in richtexts with working links

### DIFF
--- a/src/components/BaseComponent.tsx
+++ b/src/components/BaseComponent.tsx
@@ -5,6 +5,7 @@ import { RequestRouteChangeParams } from "@/types/components";
 import { FSXAGetters, FSXAActions, getFSXAConfiguration } from "@/store";
 import { FSXAApi, FSXAContentMode, NavigationData } from "fsxa-api";
 import { GCAPage } from "fsxa-api/dist/types";
+import { extractLinkMarkup } from "@/utils/dom";
 
 @Component
 class BaseComponent<Props> extends TsxComponent<Props> {
@@ -19,6 +20,56 @@ class BaseComponent<Props> extends TsxComponent<Props> {
       ),
   })
   handleRouteChangeRequest!: (params: RequestRouteChangeParams) => void;
+
+  getUrlByReferenceIdAndType(
+    referenceId: string,
+    referenceType: "PageRef",
+  ): string | null {
+    return this.$store.getters[FSXAGetters.getReferenceUrl](
+      referenceId,
+      referenceType,
+    );
+  }
+
+  createLinksInRichText(
+    text: string,
+    handleLinkData?: (
+      type: string,
+      data: Record<string, string>,
+    ) => {
+      isInternalLink: boolean;
+      linkAttributes: Record<string, any>;
+    } | null,
+  ): string {
+    return extractLinkMarkup(text, (type, data) => {
+      if (handleLinkData) {
+        const result = handleLinkData(type, data);
+        if (result) {
+          return {
+            "data-link-internal": result.isInternalLink ? "true" : null,
+            ...result.linkAttributes,
+          };
+        }
+      }
+      switch (type) {
+        case "internal_link":
+          return {
+            "data-link-internal": "true",
+            href: this.getUrlByReferenceIdAndType(
+              data.lt_link.value.identifier,
+              data.lt_link.value.fsType,
+            ),
+          };
+        case "external_link":
+          return {
+            href: data.lt_url.value || null,
+            target: data.lt_link_behavior.value.identifier || null,
+          };
+        default:
+          return {};
+      }
+    });
+  }
 
   get isEditMode() {
     return this.$store.getters[FSXAGetters.mode] === "preview";

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -124,7 +124,10 @@ class Page extends BaseComponent<PageProps> {
       });
     }
     window.addEventListener("click", event => {
-      if ((event.target as HTMLElement).dataset.linkInternal) {
+      if (
+        "linkInternal" in (event.target as HTMLElement).dataset &&
+        (event.target as HTMLElement).dataset.linkInternal === "true"
+      ) {
         event.preventDefault();
         event.stopImmediatePropagation();
         this.handleRouteChange((event.target as any).pathname);

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -123,6 +123,13 @@ class Page extends BaseComponent<PageProps> {
         return false;
       });
     }
+    window.addEventListener("click", event => {
+      if ((event.target as HTMLElement).dataset.linkInternal) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        this.handleRouteChange((event.target as any).pathname);
+      }
+    });
   }
 
   initialize({

--- a/src/components/Section/components/InterestingFactsSection.tsx
+++ b/src/components/Section/components/InterestingFactsSection.tsx
@@ -27,7 +27,7 @@ class InterestingFactsSection extends BaseSection<Payload> {
       <Sections.InterestingFactsSection
         headline={this.payload.st_headline}
         tagline={this.payload.st_tagline}
-        text={this.payload.st_text}
+        text={this.createLinksInRichText(this.payload.st_text)}
         counters={(this.payload.st_counters || []).map(counter => ({
           previewId: counter.previewId,
           value: counter.data.st_number,

--- a/src/components/Section/components/TeaserSection.tsx
+++ b/src/components/Section/components/TeaserSection.tsx
@@ -40,7 +40,7 @@ class TeaserSection extends BaseSection<Payload> {
       <Sections.TeaserSection
         headline={this.payload.st_headline}
         kicker={this.payload.st_kicker}
-        text={this.payload.st_text}
+        text={this.createLinksInRichText(this.payload.st_text)}
         buttonText={this.payload.st_button?.data.lt_button_text}
         handleButtonClick={() => {
           this.handleRouteChangeRequest({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -110,6 +110,7 @@ const GETTER_LOCALE = "locale";
 const GETTER_ITEM = "item";
 const GETTER_PAGE_BY_URL = "getPageIdByUrl";
 const GETTER_MODE = "mode";
+const GETTER_REFERENCE_URL = "getReferenceUrl";
 
 export const FSXAGetters = {
   [Getters.appState]: `${prefix}/${Getters.appState}`,
@@ -121,6 +122,7 @@ export const FSXAGetters = {
   [GETTER_ITEM]: `${prefix}/${GETTER_ITEM}`,
   [GETTER_PAGE_BY_URL]: `${prefix}/${GETTER_PAGE_BY_URL}`,
   [GETTER_MODE]: `${prefix}/${GETTER_MODE}`,
+  [GETTER_REFERENCE_URL]: `${prefix}/${GETTER_REFERENCE_URL}`,
 };
 
 const isMatchingRoute = (
@@ -242,7 +244,6 @@ export function getFSXAModule<R extends RootState>(
                 if (!currentRoute.customData || !currentRoute.customData.fsxa)
                   return false;
                 try {
-                  console.log(currentRoute.customData.fsxa.regexp);
                   const fsxaData = JSON.parse(currentRoute.customData.fsxa);
                   return isMatchingRoute(
                     currentRoute.seoRoute,
@@ -251,7 +252,6 @@ export function getFSXAModule<R extends RootState>(
                     payload.path!,
                   );
                 } catch (err) {
-                  console.log("Could not parse JSON", err);
                   return false;
                 }
                 return false;
@@ -317,7 +317,6 @@ export function getFSXAModule<R extends RootState>(
             });
           }
         } catch (error) {
-          console.log("ERROR", error);
           commit("setError", {
             appState: FSXAAppState.error,
             error: {
@@ -440,6 +439,16 @@ export function getFSXAModule<R extends RootState>(
         return (navigationData as NavigationData).seoRouteMap[url] || null;
       },
       [GETTER_MODE]: (state): FSXAContentMode => state.mode as FSXAContentMode,
+      [GETTER_REFERENCE_URL]: state => (
+        referenceId: string,
+        referenceType: "PageRef",
+      ) => {
+        const page =
+          referenceType === "PageRef"
+            ? state.navigation?.idMap[referenceId]
+            : null;
+        return page ? page.seoRoute : null;
+      },
     },
   };
 }

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -55,6 +55,43 @@ export class FSXABaseComponent<Props> extends Component<Props> {
    * Make sure that you always provide some kind of fallback since this route change will only be available when javascript is enabled
    */
   handleRouteChangeRequest: (params: RequestRouteChangeParams) => void;
+
+  /**
+   * This method will return the mapped url for the given input parameters
+   *
+   * If no matching url could be found *null* is returned.
+   */
+  getUrlByReferenceIdAndType: (
+    referenceId: string,
+    referenceType: string,
+  ) => string | null;
+
+  /**
+   * FirstSpirit will create special formats for link templates in the richtext-text
+   *
+   * You can pass in the richtext received from the api to create working application links
+   *
+   * An optional handler can be provided to override or extend the link template generation
+   */
+  createLinksInRichText: (
+    /**
+     * the richtext received through the api
+     */
+    text: string,
+    /**
+     * optional handler to override / extend link template generation
+     */
+    handleLinkData?: (
+      type: string,
+      data: Record<string, string>,
+    ) => {
+      /**
+       * set this flag to true if this is an internal link
+       */
+      isInternalLink: boolean;
+      linkAttributes: Record<string, any>;
+    } | null,
+  ) => string;
   /**
    * Access your stored data in the vuex store
    * @param key key of the stored item

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -44,31 +44,38 @@ export const extractLinkMarkup = (
     data: Record<string, any>,
   ) => Record<string, any>,
 ) => {
-  const regex = /<div data-fs-type="link\.(.*?)"><script type="application\/json">(.*?)<\/script><a>.*?<\/a><\/div>/gm;
-
-  const linkTemplates: LinkTemplate[] = [];
-  let m;
-  while ((m = regex.exec(text)) !== null) {
-    // This is necessary to avoid infinite loops with zero-width matches
-    if (m.index === regex.lastIndex) {
-      regex.lastIndex++;
+  const regex = /<div data-fs-type="link\.(.*?)">\s*<script type="application\/json">(.*?)<\/script>\s*<a>.*?<\/a>\s*<\/div>/gm;
+  try {
+    const linkTemplates: LinkTemplate[] = [];
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      // This is necessary to avoid infinite loops with zero-width matches
+      if (match.index === regex.lastIndex) {
+        regex.lastIndex++;
+      }
+      linkTemplates.push({
+        stringToReplace: match[0],
+        type: match[1] as any,
+        data: JSON.parse(match[2]),
+      });
     }
-    linkTemplates.push({
-      stringToReplace: m[0],
-      type: m[1] as any,
-      data: JSON.parse(m[2]),
+    let result = text || "";
+    linkTemplates.forEach(data => {
+      const hrefProps = createHrefAttributes(data.type, data.data);
+      result = result.replace(
+        data.stringToReplace,
+        `<a ${Object.keys(hrefProps)
+          .map(
+            prop => hrefProps[prop] != null && `${prop}="${hrefProps[prop]}"`,
+          )
+          .filter(Boolean)
+          .join(" ")}>${data.data.lt_text.value}</a>`,
+      );
     });
+    return result;
+  } catch (err) {
+    console.log("Error creating linkTemplates", err, text);
+    // return original text if error occured
+    return text;
   }
-  let result = text;
-  linkTemplates.forEach(data => {
-    const hrefProps = createHrefAttributes(data.type, data.data);
-    result = result.replace(
-      data.stringToReplace,
-      `<a ${Object.keys(hrefProps)
-        .map(prop => hrefProps[prop] && `${prop}="${hrefProps[prop]}"`)
-        .filter(Boolean)
-        .join(" ")}>${data.data.lt_text.value}</a>`,
-    );
-  });
-  return result;
 };

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,0 +1,95 @@
+export interface LinkData {
+  lt_text: {
+    value: string;
+  };
+}
+
+export interface InternalLinkData extends LinkData {
+  lt_link: {
+    value: {
+      fsType: "PageRef";
+      identifier: string;
+    };
+  };
+}
+
+export interface ExternalLinkData extends LinkData {
+  lt_url: {
+    value: string;
+  };
+  lt_link_behavior: {
+    value: {
+      identifier: string;
+    };
+  };
+}
+
+export type LinkTemplate = {
+  stringToReplace: string;
+} & (
+  | {
+      type: "internal_link";
+      data: InternalLinkData;
+    }
+  | {
+      type: "external_link";
+      data: ExternalLinkData;
+    }
+);
+
+export const extractLinkMarkup = (
+  text: string,
+  createHrefAttributes: (
+    type: string,
+    data: Record<string, any>,
+  ) => Record<string, any>,
+) => {
+  const regex = /<div data-fs-type="link\.(.*?)"><script type="application\/json">(.*?)<\/script><a>.*?<\/a><\/div>/gm;
+
+  const linkTemplates: LinkTemplate[] = [];
+  let m;
+  while ((m = regex.exec(text)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (m.index === regex.lastIndex) {
+      regex.lastIndex++;
+    }
+    linkTemplates.push({
+      stringToReplace: m[0],
+      type: m[1] as any,
+      data: JSON.parse(m[2]),
+    });
+  }
+  let result = text;
+  linkTemplates.forEach(data => {
+    const hrefProps = createHrefAttributes(data.type, data.data);
+    result = result.replace(
+      data.stringToReplace,
+      `<a ${Object.keys(hrefProps)
+        .map(prop => hrefProps[prop] && `${prop}="${hrefProps[prop]}"`)
+        .filter(Boolean)
+        .join(" ")}>${data.data.lt_text.value}</a>`,
+    );
+  });
+  return result;
+
+  /**let m;
+  let newValue = text;
+  while ((m = regex.exec(text)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (m.index === regex.lastIndex) {
+      regex.lastIndex++;
+    }
+    const json = JSON.parse(m[2]);
+    newValue = newValue.replace(
+      m[0],
+      `
+            <a class="lsg--link" href="#${getFootnoteIdentifier(
+              json.note.value,
+            )}" title="${json.title.value}">${json.text.value}<sup>${
+        json.note.value
+      }</sup></a>
+        `,
+    );
+  }
+  return newValue;**/
+};

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -71,25 +71,4 @@ export const extractLinkMarkup = (
     );
   });
   return result;
-
-  /**let m;
-  let newValue = text;
-  while ((m = regex.exec(text)) !== null) {
-    // This is necessary to avoid infinite loops with zero-width matches
-    if (m.index === regex.lastIndex) {
-      regex.lastIndex++;
-    }
-    const json = JSON.parse(m[2]);
-    newValue = newValue.replace(
-      m[0],
-      `
-            <a class="lsg--link" href="#${getFootnoteIdentifier(
-              json.note.value,
-            )}" title="${json.title.value}">${json.text.value}<sup>${
-        json.note.value
-      }</sup></a>
-        `,
-    );
-  }
-  return newValue;**/
 };


### PR DESCRIPTION
FirstSpirit is adding special formats for link templates into the richtext output that have to be
parsed and replaced to work as links in the application content. The `createLinksInRichText`-method
(provided by the FSXABaseComponent) will replace the special formats with working links. Make sure
that you transform the html-content received through the api with the newly provided method.