### PR TITLE
feat(tpp-snap): remove the bundled tpp-snap version and dynamically load specified version

### DIFF
--- a/examples/sfc/components/AppLayout.vue
+++ b/examples/sfc/components/AppLayout.vue
@@ -5,7 +5,9 @@
         class="pl-w-full pl-flex pl-items-center pl-justify-center pl-px-4 md:pl-px-6 lg:pl-px-10 pl-py-3"
         v-if="navigationData"
       >
-        <div class="pl-flex-shrink-0 pl-font-bold">SFC App</div>
+        <div class="pl-flex-shrink-0 pl-font-bold">
+          SFC App
+        </div>
         <div class="pl-flex-1 pl-text-right">
           <ul class="pl-inline-block">
             <li

--- a/examples/tsx/index.tsx
+++ b/examples/tsx/index.tsx
@@ -42,7 +42,6 @@ class App extends TsxComponent<{}> {
         currentPath={this.route}
         devMode
         handleRouteChange={this.changeRoute}
-        globalSettingsKey="global_settings"
         components={{
           appLayout: AppLayout,
           layouts: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10198,11 +10198,6 @@
       "dev": true,
       "optional": true
     },
-    "fs-tpp-api": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/fs-tpp-api/-/fs-tpp-api-1.3.1.tgz",
-      "integrity": "sha512-a7U22VHa9uznwJKMY7yqMII8nmC4h0YNi35nYwSvlovBOvQpZHSgP5GyQtzhUiEX00+LofiNaPs1FqLhtmRoFg=="
-    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "core-js": "^2.6.10",
     "date-fns": "^2.14.0",
-    "fs-tpp-api": "1.3.1",
     "fsxa-api": "^5.0.0",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -84,8 +84,10 @@ class App extends TsxComponent<AppProps> {
     // we will load tpp-snap, if we are in devMode
     if (this.isEditMode) {
       importTPPSnapAPI(this.tppVersion)
-        .then(() => {
-          const TPP_SNAP = getTPPSnap();
+        .then(TPP_SNAP => {
+          if (!TPP_SNAP) {
+            throw new Error("Could not find global TPP_SNAP object.");
+          }
           TPP_SNAP.onRequestPreviewElement((previewId: string) => {
             const pageId = previewId.split(".")[0];
             const nextPage = this.navigationData?.idMap[pageId];
@@ -125,9 +127,7 @@ class App extends TsxComponent<AppProps> {
           this.currentPath,
         );
         if (currentRoute) {
-          (window as any).TPP_SNAP.setPreviewElement(
-            `${currentRoute.id}.${this.locale}`,
-          );
+          getTPPSnap().setPreviewElement(`${currentRoute.id}.${this.locale}`);
         }
         // eslint-disable-next-line
       } catch (err) {}

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -5,6 +5,7 @@ import BaseComponent from "@/components/base/BaseComponent";
 import { FSXA_INJECT_KEY_LOADER } from "@/constants";
 
 import Layout from "./Layout";
+import { getTPPSnap } from "@/utils";
 
 export interface PageProps {
   id?: string;
@@ -33,17 +34,15 @@ class Page extends BaseComponent<PageProps> {
     if (!this.pageData && !this.loadedPage) {
       this.fetchPage();
     }
-    if (this.isEditMode && this.page) {
-      // eslint-disable-next-line
-      const TPP_SNAP = require("fs-tpp-api/snap");
+    const TPP_SNAP = getTPPSnap();
+    if (this.isEditMode && this.page && TPP_SNAP) {
       TPP_SNAP.setPreviewElement(this.page.previewId);
     }
   }
 
   updated() {
-    if (this.isEditMode && this.page) {
-      // eslint-disable-next-line
-      const TPP_SNAP = require("fs-tpp-api/snap");
+    const TPP_SNAP = getTPPSnap();
+    if (this.isEditMode && this.page && TPP_SNAP) {
       TPP_SNAP.setPreviewElement(this.page.previewId);
     }
   }

--- a/src/components/base/BaseComponent.tsx
+++ b/src/components/base/BaseComponent.tsx
@@ -14,7 +14,10 @@ import {
   triggerRouteChange,
 } from "@/utils/getters";
 import { RequestRouteChangeParams } from "@/types/components";
-import { FSXA_INJECT_KEY_DEV_MODE } from "@/constants";
+import {
+  FSXA_INJECT_KEY_DEV_MODE,
+  FSXA_INJECT_KEY_TPP_VERSION,
+} from "@/constants";
 import { findNavigationItemInNavigationData } from "@/utils/getters";
 import { determineCurrentRoute } from "@/utils/navigation";
 
@@ -30,6 +33,8 @@ class BaseComponent<
     from: "currentPath",
   })
   private currentPath!: string;
+  @InjectReactive({ from: FSXA_INJECT_KEY_TPP_VERSION })
+  fsTppVersion!: string;
   @Inject({ from: FSXA_INJECT_KEY_DEV_MODE, default: false })
   isDevMode!: boolean;
   @Inject({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,3 +5,4 @@ export const FSXA_INJECT_KEY_LAYOUTS = "fsxa.layouts";
 export const FSXA_INJECT_KEY_SECTIONS = "fsxa.sections";
 export const FSXA_INJECT_KEY_LOADER = "fsxa.loader";
 export const FSXA_INJECT_KEY_SET_PORTAL_CONTENT = "fsxa.setPortalContent";
+export const FSXA_INJECT_KEY_TPP_VERSION = "fsxa.tppVersion";

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -19,6 +19,14 @@ export class FSXABaseComponent<
    * Check wether devMode is active
    */
   isDevMode: boolean;
+
+  /**
+   * The currently used ts-tpp-api version.
+   *
+   * *Hint:* If you want to work with specific features make sure that the current version supports them. The fs-tpp-api will only be injected, when isEditMode = true
+   */
+  fsTppVersion: string;
+
   /**
    * This method will trigger a route change request
    *
@@ -41,21 +49,6 @@ export class FSXABaseComponent<
    * If null is returned, no current route could be matched to the current path
    */
   get currentPage(): NavigationItem | null;
-
-  /**
-   * The current RichText structure encapsulates linking logic. To make sure, that the contained links are clickable,
-   * invoke this method. The links will then be transformed.
-   */
-  createLinksInRichText(
-    text: string,
-    handleLinkData?: (
-      type: string,
-      data: Record<string, string>,
-    ) => {
-      isInternalLink: boolean;
-      linkAttributes: Record<string, any>;
-    } | null,
-  ): string;
 
   /**
    * Check if this app is delivering preview or released data
@@ -290,18 +283,18 @@ export interface AppProps {
    */
   devMode?: boolean;
   /**
-   * It is possible to provide global content to the fsxa through a GCAPage.
-   *
-   * Provide its uid to automatically load the content of the GCAPage on initialization.
-   */
-  globalSettingsKey?: string;
-  /**
    * Required callback that will be triggered, when the route should be changed
    *
    * Info: We do not know in which context you are using our pattern-library, so we decided that you should have the last word about routing.
    * You can use your own routing technology but rely on the pattern-library to do the heavy lifting.
    */
   handleRouteChange: (nextRoute: string) => void;
+  /**
+   * You can specify which fs-tpp-api version should be loaded in preview-mode
+   *
+   * The TPP-API is used for enabling the editing experience in the OCM
+   */
+  fsTppVersion?: string;
 }
 export class FSXAApp extends Component<AppProps> {}
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,11 +1,17 @@
 export const isClient = () => typeof window !== "undefined";
 
-export const importTPPSnapAPI = (version: string): Promise<void> => {
+export const getTPPSnap = (): any | null => {
+  return (window && (window as any).TPP_SNAP) || null;
+};
+
+export const importTPPSnapAPI = async (
+  version: string,
+): Promise<any | null> => {
   return new Promise((resolve, reject) => {
     const script = document.createElement("script");
     // We will wait for tpp to load until we resolve this promise
     script.onload = () => {
-      resolve();
+      resolve(getTPPSnap());
     };
     script.onerror = () => {
       reject();
@@ -13,8 +19,4 @@ export const importTPPSnapAPI = (version: string): Promise<void> => {
     script.src = `https://cdn.jsdelivr.net/npm/fs-tpp-api@${version}/snap.js`;
     document.head.appendChild(script);
   });
-};
-
-export const getTPPSnap = (): any | null => {
-  return (window && (window as any).TPP_SNAP) || null;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,20 @@
 export const isClient = () => typeof window !== "undefined";
+
+export const importTPPSnapAPI = (version: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    // We will wait for tpp to load until we resolve this promise
+    script.onload = () => {
+      resolve();
+    };
+    script.onerror = () => {
+      reject();
+    };
+    script.src = `https://cdn.jsdelivr.net/npm/fs-tpp-api@${version}/snap.js`;
+    document.head.appendChild(script);
+  });
+};
+
+export const getTPPSnap = (): any | null => {
+  return (window && (window as any).TPP_SNAP) || null;
+};


### PR DESCRIPTION
You can now pass the version of the fs-tpp-api which should be used. This gives you more flexibility
to use new features, when the standard is not updated yet or helps you, when your server is running
an older version. If you do not specify a version the default will be 2.2.1 for now. If this
changes, we will inform you in our release notes.