### PR TITLE
feat(devmodeinfo): added the possibility to display a custom component to declare missing components

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -20,6 +20,7 @@ import {
   FSXA_INJECT_KEY_LOADER,
   FSXA_INJECT_KEY_COMPONENTS,
   FSXA_INJECT_KEY_TPP_VERSION,
+  FSXA_INJECT_DEV_MODE_INFO,
 } from "@/constants";
 import Page from "./Page";
 import ErrorBoundary from "./internal/ErrorBoundary";
@@ -52,6 +53,8 @@ class App extends TsxComponent<AppProps> {
     this.components?.sections || {};
   @ProvideReactive(FSXA_INJECT_KEY_LOADER) injectedLoader =
     this.components?.loader || null;
+  @ProvideReactive(FSXA_INJECT_DEV_MODE_INFO) injectedInfoError =
+    this.components?.devModeInfo || null;
 
   @Watch("currentPath")
   onCurrentPathChange(nextPath: string) {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -61,6 +61,43 @@ class Layout<Data = {}, Meta = {}> extends RenderUtils<
     this.setPortalContent(this.renderDevInfo(true));
   }
 
+  renderDevModeInfo() {
+    const DevModeInfoComponent = this.components.devModeInfo || null;
+    if (DevModeInfoComponent)
+      return <DevModeInfoComponent type="layout" componentName={this.type} />;
+    return (
+      <div>
+        You can pass your own component by adding it to the{" "}
+        <Code inline language="js">
+          components.layouts
+        </Code>{" "}
+        map.
+        <Code class="pl-mt-4" language="tsx">
+          {`import YourCustomComponent from "...";
+
+<FSXAApp
+  components={{
+    layouts: {
+      "${this.type}": YourCustomComponent,
+    }
+  }}
+/>`}
+        </Code>
+        If you are not using the fsxa-pattern-library directly make sure to
+        check the documentation of your project specific integration.
+        <br />
+        <br />
+        You can extend the
+        <Code class="pl-mx-1" inline language="tsx">
+          FSXABaseLayout
+        </Code>
+        to get access to many useful utility methods.
+        <br />
+        <br />
+      </div>
+    );
+  }
+
   renderDevInfo(isOverlay = false) {
     return (
       <InfoBox
@@ -94,37 +131,7 @@ class Layout<Data = {}, Meta = {}> extends RenderUtils<
           )
         }
       >
-        {!isOverlay && (
-          <div>
-            You can pass your own component by adding it to the{" "}
-            <Code inline language="js">
-              components.layouts
-            </Code>{" "}
-            map.
-            <Code class="pl-mt-4" language="tsx">
-              {`import YourCustomComponent from "...";
-
-<FSXAApp
-  components={{
-    layouts: {
-      "${this.type}": YourCustomComponent,
-    }
-  }}
-/>`}
-            </Code>
-            If you are not using the fsxa-pattern-library directly make sure to
-            check the documentation of your project specific integration.
-            <br />
-            <br />
-            You can extend the
-            <Code class="pl-mx-1" inline language="tsx">
-              FSXABaseLayout
-            </Code>
-            to get access to many useful utility methods.
-            <br />
-            <br />
-          </div>
-        )}
+        {!isOverlay && this.renderDevModeInfo()}
         Your custom layout will receive the following properties:
         <TabbedContent
           tabs={[

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -45,6 +45,43 @@ class Section<
     this.setPortalContent(this.renderDevInfo(true));
   }
 
+  renderImportInformation() {
+    const DevModeInfoComponent = this.components.devModeInfo || null;
+    if (DevModeInfoComponent)
+      return <DevModeInfoComponent type="section" componentName={this.type} />;
+    return (
+      <div>
+        You can pass your own component by adding it to the{" "}
+        <Code inline language="js">
+          components
+        </Code>{" "}
+        map.
+        <Code class="pl-mt-4" language="tsx">
+          {`import YourCustomComponent from "...";
+
+<FSXAApp
+  components={{
+    sections: {
+      "${this.type}": YourCustomComponent,
+    }
+  }}
+/>`}
+        </Code>
+        If you are not using the fsxa-pattern-library directly make sure to
+        check the documentation of your project specific integration.
+        <br />
+        <br />
+        You can extend the
+        <Code class="pl-mx-1" inline language="tsx">
+          FSXABaseSection
+        </Code>
+        to get access to many useful utility methods.
+        <br />
+        <br />
+      </div>
+    );
+  }
+
   renderDevInfo(isOverlay = false) {
     return (
       <InfoBox
@@ -78,37 +115,7 @@ class Section<
           )
         }
       >
-        {!isOverlay && (
-          <div>
-            You can pass your own component by adding it to the{" "}
-            <Code inline language="js">
-              components
-            </Code>{" "}
-            map.
-            <Code class="pl-mt-4" language="tsx">
-              {`import YourCustomComponent from "...";
-
-<FSXAApp
-  components={{
-    sections: {
-      "${this.type}": YourCustomComponent,
-    }
-  }}
-/>`}
-            </Code>
-            If you are not using the fsxa-pattern-library directly make sure to
-            check the documentation of your project specific integration.
-            <br />
-            <br />
-            You can extend the
-            <Code class="pl-mx-1" inline language="tsx">
-              FSXABaseSection
-            </Code>
-            to get access to many useful utility methods.
-            <br />
-            <br />
-          </div>
-        )}
+        {!isOverlay && this.renderImportInformation()}
         Your custom section will receive the following properties:
         <TabbedContent
           tabs={

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,3 +6,4 @@ export const FSXA_INJECT_KEY_SECTIONS = "fsxa.sections";
 export const FSXA_INJECT_KEY_LOADER = "fsxa.loader";
 export const FSXA_INJECT_KEY_SET_PORTAL_CONTENT = "fsxa.setPortalContent";
 export const FSXA_INJECT_KEY_TPP_VERSION = "fsxa.tppVersion";
+export const FSXA_INJECT_DEV_MODE_INFO = "fsxa.devModeInfo";

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -254,6 +254,7 @@ export interface AppComponents {
    */
   layouts?: Record<string, any>;
   richtext?: Record<string, any>;
+  devModeInfo?: any;
 }
 
 export interface AppProps {


### PR DESCRIPTION
We have added the possibility to display a custom message for the case when a component is missing.
This message is rendered in a component with is defined via the components object in the AppProps.
When no component is provided the default message will be shown.