### PR TITLE
fix(section.tsx): added missing prefix to avoid name clashing for group class

### DIFF
--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -190,7 +190,7 @@ class Section<
       );
       return (
         <ErrorBoundary
-          class="group"
+          class="pl-group"
           title={`Error rendering Section: ${MappedSection &&
             MappedSection.name}`}
         >


### PR DESCRIPTION
…up class

In the render method, a prefix was added to the class, which ensures that classes that have a group
membership now act individually from each other