### PR TITLE
fix(tpp-snap cropping): provide temporary fix for cropping multiple resolutions

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -107,6 +107,22 @@ class App extends TsxComponent<AppProps> {
                 if (nextPage) this.requestRouteChange(nextPage.seoRoute);
               });
           });
+          // Temporary solution to enable the cropping of images with multiple resolutions when using the data-tpp-context-image-resolution.
+          // Should be removed after OCM-518 is done.
+          TPP_SNAP.overrideDefaultButton("crop", {
+            execute: async ({
+              previewId,
+              $node: {
+                dataset: { tppContextImageResolution = "ORIGINAL" },
+              },
+            }: {
+              previewId: string;
+              $node: { dataset: { tppContextImageResolution: string } };
+            }) => {
+              const resolutions = tppContextImageResolution.split(",");
+              TPP_SNAP.cropImage(previewId, resolutions);
+            },
+          });
           TPP_SNAP.onRerenderView(() => {
             window.setTimeout(() => this.initialize(), 300);
             return false;


### PR DESCRIPTION
We've added a temporary fix when multiple resolutions are provided via the
`data-tpp-context-image-resolution` tag. Currently it is interpreted as one string. Now it will be
split when an `,` is provided. For example:
`data-tpp-context-image-resolution="FirstResolution,SecondResolution"`. Make sure **not** to include
any whitespaces.