### PR TITLE
feat(package.json & package-lock.json): update fsxa-api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10433,9 +10433,9 @@
       "optional": true
     },
     "fsxa-api": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-9.0.2.tgz",
-      "integrity": "sha512-P4eACccttYnxSF9pODEFYraCVN3VdaQD7OEy+oIS4U52QiX1csyH7G0tW7mNvCGARudkjOhsohK4MdmEfVu6aw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-10.0.0.tgz",
+      "integrity": "sha512-bf0xUNXbp083b7PRZYVW7g8NdfSPwaucyV980uar0X6887PE9P0XGZxNH9IKoCFOxKPXCO5HJB91P6nKI19crA==",
       "requires": {
         "@types/ws": "^8.2.2",
         "better-sse": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "README.md"
   ],
   "dependencies": {
-    "fsxa-api": "^9.0.2",
+    "fsxa-api": "^10.0.0",
     "prismjs": "^1.27.0",
     "setimmediate": "^1.0.5",
     "vue": "^2.6.14",


### PR DESCRIPTION
Update fsxa-api to latest major version 10.0.0

BREAKING CHANGE: Links inside of RichtTextElements will now be mapped in the same way as the value
of CMS_INPUT_LINK. Refer to FSXA-API changelog for more details.