### PR TITLE
feat(snap): prevent loading snap.js when PWA is the top frame

### DIFF
--- a/src/utils/tpp-snap.spec.ts
+++ b/src/utils/tpp-snap.spec.ts
@@ -4,7 +4,7 @@ declare interface Window {
   TPP_SNAP?: any;
 }
 
-describe("don't load snap", () => {
+describe("snap loading", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
     Object.defineProperties(window, {
@@ -15,7 +15,7 @@ describe("don't load snap", () => {
     });
   });
 
-  it("don't load for top-frame pwa's", async () => {
+  it("Won't add tpp snap script tags, when the application is the top frame", async () => {
     importTPPSnapAPI();
     expect(document.body.innerHTML).toEqual("");
   });

--- a/src/utils/tpp-snap.spec.ts
+++ b/src/utils/tpp-snap.spec.ts
@@ -4,10 +4,35 @@ declare interface Window {
   TPP_SNAP?: any;
 }
 
+describe("don't load snap", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    Object.defineProperties(window, {
+      TPP_SNAP: {
+        value: undefined,
+        writable: true,
+      },
+    });
+  });
+
+  it("don't load for top-frame pwa's", async () => {
+    importTPPSnapAPI();
+    expect(document.body.innerHTML).toEqual("");
+  });
+});
+
 describe("tpp snap lib", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
-    Object.assign(window, { TPP_SNAP: undefined });
+    Object.defineProperties(window, {
+      TPP_SNAP: {
+        value: undefined,
+        writable: true,
+      },
+      top: {
+        value: "<CONTENT-CREATOR-FRAME>",
+      },
+    });
   });
 
   it("only version parameter set", async () => {

--- a/src/utils/tpp-snap.ts
+++ b/src/utils/tpp-snap.ts
@@ -16,12 +16,12 @@ export const importTPPSnapAPI = (
   options: ImportTPPSnapAPIOptions = {},
 ): Promise<any> =>
   new Promise(resolve => {
-    // Never resolve the promise, if the PWA is `window.top`,
-    //  to prevent console errors during local development.
+    // To prevent console errors during local development,
+    // never resolve the promise, if the PWA is `window.top`,
     // No content can be changed outside the ContentCreator!
     if (window.top === window.self) {
       console.warn(
-        "You are running FSXA in PREVIEW mode outside of the ContentCreator. No InEdit features could be used.",
+        "You are running your application outside of the ContentCreator. InEdit will not be available.",
       );
       return;
     }

--- a/src/utils/tpp-snap.ts
+++ b/src/utils/tpp-snap.ts
@@ -16,6 +16,11 @@ export const importTPPSnapAPI = (
   options: ImportTPPSnapAPIOptions = {},
 ): Promise<any> =>
   new Promise(resolve => {
+    // Never resolve the promise, if the PWA is `window.top`,
+    //  to prevent console errors during local development.
+    // No content can be changed outside the ContentCreator!
+    if (window.top === window.self) return;
+
     if (isClient()) {
       const tppSnap = getTPPSnap();
       if (tppSnap !== null) {

--- a/src/utils/tpp-snap.ts
+++ b/src/utils/tpp-snap.ts
@@ -19,7 +19,12 @@ export const importTPPSnapAPI = (
     // Never resolve the promise, if the PWA is `window.top`,
     //  to prevent console errors during local development.
     // No content can be changed outside the ContentCreator!
-    if (window.top === window.self) return;
+    if (window.top === window.self) {
+      console.warn(
+        "You are running FSXA in PREVIEW mode outside of the ContentCreator. No InEdit features could be used.",
+      );
+      return;
+    }
 
     if (isClient()) {
       const tppSnap = getTPPSnap();


### PR DESCRIPTION
Prevent error messages during local development outside of ContentCreator